### PR TITLE
Configura workflow para ramas de tareas

### DIFF
--- a/.github/workflows/dev-task-workflow.yml
+++ b/.github/workflows/dev-task-workflow.yml
@@ -3,7 +3,7 @@ name: Develop Task Workflow
 on:
   push:
     branches:
-      - "t0"
+      - "t0**"
 
 jobs:
   linter:

--- a/.github/workflows/dev-task-workflow.yml
+++ b/.github/workflows/dev-task-workflow.yml
@@ -1,0 +1,25 @@
+name: Develop Task Workflow
+
+on:
+  push:
+    branches:
+      - "t0"
+
+jobs:
+  linter:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+
+      - name: Setup Deno
+        uses: denolib/setup-deno@v2
+        with:
+          deno-version: "v1.13.2"
+
+      - name: Cache dependencies
+        run: deno cache --unstable ./deps.ts
+        
+      - name: Run linter
+        run: deno lint

--- a/.github/workflows/testing-workflow.yml
+++ b/.github/workflows/testing-workflow.yml
@@ -1,4 +1,4 @@
-name: Muevete API Workflow
+name: Testing Workflow
 
 on:
   push:


### PR DESCRIPTION
Se tiene que ajustar el workflow en futuros commits, pero define workflows distintos para develop y ramas de tareas. Se deben tener en cuenta también a las ramas que no sigan con la nomenclatura de tareas.